### PR TITLE
Fix broken links to Gardener documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .changelog
 tmp
+.idea

--- a/gardener-addon/manual-install.md
+++ b/gardener-addon/manual-install.md
@@ -3,8 +3,8 @@
 ## Prerequisites
 
 Enable the following extensions for the shoot cluster:
-* [`shoot-dns-service`](https://gardener.cloud/050-tutorials/content/howto/gardener_dns_management/#configuration) extension which adds the DNSEntry CRD 
-* [`shoot-cert-service`](https://gardener.cloud/050-tutorials/content/howto/gardener_certificate_management/#extension-installation) extension which adds the Certificate CRD
+* [`shoot-dns-service`](https://gardener.cloud/documentation/050-tutorials/content/howto/gardener_dns_management/#configuration) extension which adds the DNSEntry CRD 
+* [`shoot-cert-service`](https://gardener.cloud/documentation/050-tutorials/content/howto/gardener_certificate_management/#extension-installation) extension which adds the Certificate CRD
   
 ```
 spec:


### PR DESCRIPTION
Since the location of the Gardener documentation changed, the links had to be updated.

**Description**

Changes proposed in this pull request:

- Fix broken links to the Gardener documentation.