### PR TITLE
Add caution about disabling Kyma installation through Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+> **CAUTION:** As a result of [Kubernetes API deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.
+
 # Kyma Marketplaces
 
 ## Overview
 
 This repository contains Kyma configuration for Cloud Marketplaces, such as Google Cloud Marketplace.
-
-> **CAUTION:** As a result of [Kubernetes API deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 This repository contains Kyma configuration for Cloud Marketplaces, such as Google Cloud Marketplace.
 
-> **CAUTION:** As a result of [Kubernetes API depreciation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.
+> **CAUTION:** As a result of [Kubernetes API deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 ## Overview
 
 This repository contains Kyma configuration for Cloud Marketplaces, such as Google Cloud Marketplace.
+
+> **CAUTION:** As a result of [Kubernetes API depreciation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -1,6 +1,6 @@
 # Kyma Google Cloud Marketplace
 
-> **CAUTION:** As a result of [Kubernetes API depreciation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.
+> **CAUTION:** As a result of [Kubernetes API deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.
 
 ## Overview
 

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -1,5 +1,7 @@
 # Kyma Google Cloud Marketplace
 
+> **CAUTION:** As a result of [Kubernetes API depreciation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.
+
 ## Overview
 
 This project provides Kyma configuration for the Google Cloud Marketplace.

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -1,7 +1,5 @@
 # Kyma Google Cloud Marketplace
 
-> **CAUTION:** As a result of [Kubernetes API deprecation](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), Kyma can no longer be installed through the GCP Marketplace. That is why, we temporary disabled Kyma on GCP Marketplace until we make changes necessary to fix the installation issues.
-
 ## Overview
 
 This project provides Kyma configuration for the Google Cloud Marketplace.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a caution informing that Kyma installation through GCP Marketplace is temporarily disabled because of Kubernetes API deprecation issues.

**Related issue(s)**
See also #https://github.com/kyma-project/kyma/issues/9022