### PR TITLE
Fix links to Gardener shoot cluster extensions

### DIFF
--- a/gardener-addon/manual-install.md
+++ b/gardener-addon/manual-install.md
@@ -3,8 +3,8 @@
 ## Prerequisites
 
 Enable the following extensions for the shoot cluster:
-* [`shoot-dns-service`](https://gardener.cloud/documentation/050-tutorials/content/howto/gardener_dns_management/#configuration) extension which adds the DNSEntry CRD 
-* [`shoot-cert-service`](https://gardener.cloud/documentation/050-tutorials/content/howto/gardener_certificate_management/#extension-installation) extension which adds the Certificate CRD
+* [`shoot-dns-service`](https://github.com/gardener/gardener-extension-shoot-dns-service) extension which adds the DNSEntry CRD 
+* [`shoot-cert-service`](https://github.com/gardener/gardener-extension-shoot-cert-service) extension which adds the Certificate CRD
   
 ```
 spec:


### PR DESCRIPTION
**Description**

The links to documentation describing the `shoot-dns-service` and `shoot-cert-service` extensions are no longer working and should be updated.

Changes proposed in this pull request:

- Fix the link to the `shoot-dns-service` extensions to point to its [GitHub repo](https://github.com/gardener/gardener-extension-shoot-dns-service)
- Fix the link to the `shoot-cert-service` extension to point to its [GitHub repo](https://github.com/gardener/gardener-extension-shoot-dns-service)

**Alternatively**, the following links to the documentation on Gardener's website could possibly also be used: 
- [External DNS management](https://gardener.cloud/documentation/concepts/networking/dns-managment/)
- [cert-management](https://gardener.cloud/documentation/concepts/networking/cert-managment/)